### PR TITLE
Use HTTPS instead of SSH for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,24 @@
 [submodule "AEM"]
 	path = AEM
-	url = git@github.com:DantaFramework/AEM.git
+	url = https://github.com/DantaFramework/AEM.git
 [submodule "AEMDemo"]
 	path = AEMDemo
-	url = git@github.com:DantaFramework/AEMDemo.git
+	url = https://github.com/DantaFramework/AEMDemo.git
 [submodule "API"]
 	path = API
-	url = git@github.com:DantaFramework/API.git
+	url = https://github.com/DantaFramework/API.git
 [submodule "Core"]
 	path = Core
-	url = git@github.com:DantaFramework/Core.git
+	url = https://github.com/DantaFramework/Core.git
 [submodule "JahiaDF"]
 	path = JahiaDF
-	url = git@github.com:DantaFramework/JahiaDF.git
+	url = https://github.com/DantaFramework/JahiaDF.git
 [submodule "JahiaDFContentDefinition"]
 	path = JahiaDFContentDefinition
-	url = git@github.com:DantaFramework/JahiaDFContentDefinition.git
+	url = https://github.com/DantaFramework/JahiaDFContentDefinition.git
 [submodule "JahiaDFDemo"]
 	path = JahiaDFDemo
-	url = git@github.com:DantaFramework/JahiaDFDemo.git
+	url = https://github.com/DantaFramework/JahiaDFDemo.git
 [submodule "Parent"]
 	path = Parent
-	url = git@github.com:DantaFramework/Parent.git
+	url = https://github.com/DantaFramework/Parent.git


### PR DESCRIPTION
Though I prefer to use SSH, HTTPS is probably a better choice for submodule URLs, since some users may not have SSH keys configured.